### PR TITLE
feat: add support for encryption at rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # burrow
 
-Burrow is a platform-agnostic, directory-scoped secrets manager. Secrets are stored outside your repos in a local SQLite store and exportable to various formats via the CLI. For a nicer dev experience, Burrow currently stores secrets in a plain-text format outside the target repo, which means that secrets can still be leaked to other users on your machine or people who gain access to your device. But, for your day-to-day dev use, this beats keeping secrets in gitignored files in your repo.
+Burrow is a platform-agnostic, directory-scoped secrets manager. Secrets are stored outside your repos in a local SQLite store and exportable to various formats via the CLI. Secret values are encrypted at rest before being written to SQLite.
 
 <p align="center">
   <img src="demo.gif" alt="burrow demo" width="600">
@@ -97,6 +97,22 @@ When you request secrets for a directory, burrow:
 2. Merges them from shallowest to deepest
 3. Deeper scopes override shallower ones
 4. Tombstones (from `unset`) block inheritance
+
+### Encryption at rest
+
+Burrow encrypts non-null secret values with AES-256-GCM before writing them to `store.db`.
+
+- **Primary key storage:** Burrow uses `Bun.secrets` to store a per-config encryption key in the OS credential store (Keychain on macOS, libsecret providers on Linux, and Credential Manager on Windows).
+- **Headless fallback:** if `Bun.secrets` is unavailable (for example in minimal CI containers without a running secret service), Burrow stores the key in `store.key` in the config directory with restrictive permissions on Unix.
+
+### Migration strategy
+
+Burrow uses a versioned database schema and encrypted payload format:
+
+1. **Schema migration (v1 → v2):** on first access, Burrow upgrades legacy stores to schema version 2.
+2. **In-place value migration:** all non-null plaintext values are encrypted and written back in place.
+3. **Idempotent migration:** values already marked as encrypted are skipped, so migration can be safely retried.
+4. **Future encrypted migrations:** encrypted payloads include a version prefix (`burrow:enc:v1:`), so future formats can be migrated deterministically.
 
 ## Library Usage
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@inquirer/password": "^5.0.3",
         "clipboardy": "^5.0.2",
         "commander": "^14.0.2",
-        "gh-release-update-notifier": "^1.0.0",
+        "gh-release-update-notifier": "^1.0.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -72,7 +72,7 @@
 
     "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
-    "gh-release-update-notifier": ["gh-release-update-notifier@1.0.0", "", {}, "sha512-KYL9pflp43usNsBP8+I3NZtcqUUH4et3erkSDqG5eLmEvh+GbjSSsF7o+iYzM+Sw6PtFq9Szh6i4dn3gs8+oDQ=="],
+    "gh-release-update-notifier": ["gh-release-update-notifier@1.0.1", "", {}, "sha512-dwZljx5/PoMRxrEPC27Gyykg9F9FbyPS+vSO8Za09xUqeR0hvJ9SMnfTn8OrPyZLHZvYmkETB9CEPIEa8HM/Yw=="],
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 

--- a/site/index.html
+++ b/site/index.html
@@ -812,8 +812,8 @@ API_KEY  sk-live-abc123  ~/projects`;
                         <p>Secrets are scoped to directories and inherited through ancestry, just like .gitignore.</p>
                     </div>
                     <div class="feature">
-                        <h3>Outside Repos</h3>
-                        <p>Secrets stored in your user profile directory, never accidentally committed.</p>
+                        <h3>Encrypted at Rest</h3>
+                        <p>Secret values are encrypted before writing to SQLite, with keys managed via Bun.secrets.</p>
                     </div>
                     <div class="feature">
                         <h3>Shell Export</h3>

--- a/src/storage/encryption.ts
+++ b/src/storage/encryption.ts
@@ -1,0 +1,190 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+import { chmod, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { isWindows } from "../platform/index.ts";
+
+const ENCRYPTION_SERVICE = "burrow";
+const ENCRYPTION_KEY_NAME_PREFIX = "store-key";
+const ENCRYPTION_KEY_FILE = "store.key";
+const ENCRYPTION_KEY_BYTES = 32;
+const ENCRYPTION_IV_BYTES = 12;
+const ENCRYPTION_AUTH_TAG_BYTES = 16;
+
+const ANY_ENCRYPTED_VALUE_PREFIX = "burrow:enc:";
+const ENCRYPTED_VALUE_PREFIX_V1 = "burrow:enc:v1:";
+
+export class SecretValueEncryptor {
+  private readonly keySecretName: string;
+  private readonly fallbackKeyPath: string;
+  private keyPromise?: Promise<Buffer>;
+
+  constructor(private readonly configDir: string) {
+    const configHash = createHash("sha256").update(configDir).digest("hex");
+    this.keySecretName = `${ENCRYPTION_KEY_NAME_PREFIX}-${configHash}`;
+    this.fallbackKeyPath = join(configDir, ENCRYPTION_KEY_FILE);
+  }
+
+  isEncryptedValue(value: string): boolean {
+    return value.startsWith(ANY_ENCRYPTED_VALUE_PREFIX);
+  }
+
+  async encrypt(plainText: string): Promise<string> {
+    const key = await this.getOrCreateKey();
+    const iv = randomBytes(ENCRYPTION_IV_BYTES);
+    const cipher = createCipheriv("aes-256-gcm", key, iv);
+    const ciphertext = Buffer.concat([
+      cipher.update(plainText, "utf8"),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+
+    return `${ENCRYPTED_VALUE_PREFIX_V1}${iv.toString("base64")}.${authTag.toString("base64")}.${ciphertext.toString("base64")}`;
+  }
+
+  async decrypt(value: string): Promise<string> {
+    if (!this.isEncryptedValue(value)) {
+      return value;
+    }
+
+    if (!value.startsWith(ENCRYPTED_VALUE_PREFIX_V1)) {
+      throw new Error("Unsupported encrypted value format in secrets store");
+    }
+
+    const encoded = value.slice(ENCRYPTED_VALUE_PREFIX_V1.length);
+    const [ivBase64, authTagBase64, ciphertextBase64, ...rest] = encoded.split(".");
+    if (
+      rest.length > 0
+      || ivBase64 === undefined
+      || authTagBase64 === undefined
+      || ciphertextBase64 === undefined
+    ) {
+      throw new Error("Malformed encrypted value in secrets store");
+    }
+
+    const iv = Buffer.from(ivBase64, "base64");
+    const authTag = Buffer.from(authTagBase64, "base64");
+    const ciphertext = Buffer.from(ciphertextBase64, "base64");
+
+    if (iv.byteLength !== ENCRYPTION_IV_BYTES) {
+      throw new Error("Malformed encrypted value (invalid IV length)");
+    }
+
+    if (authTag.byteLength !== ENCRYPTION_AUTH_TAG_BYTES) {
+      throw new Error("Malformed encrypted value (invalid auth tag length)");
+    }
+
+    const key = await this.getOrCreateKey();
+    try {
+      const decipher = createDecipheriv("aes-256-gcm", key, iv);
+      decipher.setAuthTag(authTag);
+      const decrypted = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+      ]);
+      return decrypted.toString("utf8");
+    } catch {
+      throw new Error(
+        "Failed to decrypt value from secrets store. The encryption key may be unavailable or has changed."
+      );
+    }
+  }
+
+  private async getOrCreateKey(): Promise<Buffer> {
+    this.keyPromise ??= this.loadOrCreateKey();
+    return this.keyPromise;
+  }
+
+  private async loadOrCreateKey(): Promise<Buffer> {
+    // If an on-disk fallback key exists, keep using it to avoid key drift.
+    const fallbackKey = await this.readFallbackKey();
+    if (fallbackKey) {
+      await this.tryStoreInBunSecrets(fallbackKey);
+      return fallbackKey;
+    }
+
+    const bunSecretsKey = await this.readKeyFromBunSecrets();
+    if (bunSecretsKey) {
+      return bunSecretsKey;
+    }
+
+    const generatedKey = randomBytes(ENCRYPTION_KEY_BYTES);
+    const storedInBunSecrets = await this.tryStoreInBunSecrets(generatedKey);
+    if (!storedInBunSecrets) {
+      await this.writeFallbackKey(generatedKey);
+    }
+
+    return generatedKey;
+  }
+
+  private async readKeyFromBunSecrets(): Promise<Buffer | undefined> {
+    let keyMaterial: string | null;
+
+    try {
+      keyMaterial = await Bun.secrets.get({
+        service: ENCRYPTION_SERVICE,
+        name: this.keySecretName,
+      });
+    } catch {
+      return undefined;
+    }
+
+    if (keyMaterial === null) {
+      return undefined;
+    }
+
+    return parseKeyMaterial(keyMaterial, "Bun.secrets");
+  }
+
+  private async tryStoreInBunSecrets(key: Buffer): Promise<boolean> {
+    try {
+      await Bun.secrets.set({
+        service: ENCRYPTION_SERVICE,
+        name: this.keySecretName,
+        value: key.toString("base64"),
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async readFallbackKey(): Promise<Buffer | undefined> {
+    try {
+      const keyMaterial = await readFile(this.fallbackKeyPath, "utf8");
+      return parseKeyMaterial(keyMaterial, this.fallbackKeyPath);
+    } catch (error) {
+      if (
+        typeof error === "object"
+        && error !== null
+        && "code" in error
+        && (error as { code?: string }).code === "ENOENT"
+      ) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  private async writeFallbackKey(key: Buffer): Promise<void> {
+    await writeFile(this.fallbackKeyPath, `${key.toString("base64")}\n`, "utf8");
+    if (!isWindows()) {
+      await chmod(this.fallbackKeyPath, 0o600);
+    }
+  }
+}
+
+function parseKeyMaterial(value: string, source: string): Buffer {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`Encryption key in ${source} is empty`);
+  }
+
+  const key = Buffer.from(trimmed, "base64");
+  if (key.byteLength !== ENCRYPTION_KEY_BYTES) {
+    throw new Error(
+      `Encryption key in ${source} must be ${ENCRYPTION_KEY_BYTES} bytes`
+    );
+  }
+
+  return key;
+}

--- a/src/storage/encryption.ts
+++ b/src/storage/encryption.ts
@@ -3,7 +3,8 @@ import { chmod, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { isWindows } from "../platform/index.ts";
 
-const ENCRYPTION_SERVICE = "burrow";
+const ENCRYPTION_SERVICE = "burrow.safia.dev";
+const LEGACY_ENCRYPTION_SERVICE = "burrow";
 const ENCRYPTION_KEY_NAME_PREFIX = "store-key";
 const ENCRYPTION_KEY_FILE = "store.key";
 const ENCRYPTION_KEY_BYTES = 32;
@@ -129,7 +130,15 @@ export class SecretValueEncryptor {
     }
 
     if (keyMaterial === null) {
-      return undefined;
+      // Backward compatibility: older releases used "burrow" as the service name.
+      keyMaterial = await this.readKeyFromLegacyService();
+      if (keyMaterial === null) {
+        return undefined;
+      }
+
+      const key = parseKeyMaterial(keyMaterial, `Bun.secrets (${LEGACY_ENCRYPTION_SERVICE})`);
+      await this.tryStoreInBunSecrets(key);
+      return key;
     }
 
     return parseKeyMaterial(keyMaterial, "Bun.secrets");
@@ -145,6 +154,17 @@ export class SecretValueEncryptor {
       return true;
     } catch {
       return false;
+    }
+  }
+
+  private async readKeyFromLegacyService(): Promise<string | null> {
+    try {
+      return await Bun.secrets.get({
+        service: LEGACY_ENCRYPTION_SERVICE,
+        name: this.keySecretName,
+      });
+    } catch {
+      return null;
     }
   }
 

--- a/src/storage/encryption.ts
+++ b/src/storage/encryption.ts
@@ -18,7 +18,7 @@ export class SecretValueEncryptor {
   private readonly fallbackKeyPath: string;
   private keyPromise?: Promise<Buffer>;
 
-  constructor(private readonly configDir: string) {
+  constructor(configDir: string) {
     const configHash = createHash("sha256").update(configDir).digest("hex");
     this.keySecretName = `${ENCRYPTION_KEY_NAME_PREFIX}-${configHash}`;
     this.fallbackKeyPath = join(configDir, ENCRYPTION_KEY_FILE);

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -3,8 +3,10 @@ import { chmod, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { getConfigDir } from "../platform/index.ts";
 import { isWindows } from "../platform/index.ts";
+import { SecretValueEncryptor } from "./encryption.ts";
 
 const DEFAULT_STORE_FILE = "store.db";
+const STORE_VERSION = 2;
 
 export interface SecretEntry {
   value: string | null;
@@ -29,11 +31,13 @@ export interface StorageOptions {
 export class Storage {
   private readonly configDir: string;
   private readonly storeFileName: string;
+  private readonly encryptor: SecretValueEncryptor;
   private db: Database | null = null;
 
   constructor(options: StorageOptions = {}) {
     this.configDir = options.configDir ?? getConfigDir();
     this.storeFileName = options.storeFileName ?? DEFAULT_STORE_FILE;
+    this.encryptor = new SecretValueEncryptor(this.configDir);
   }
 
   private get storePath(): string {
@@ -88,15 +92,62 @@ export class Storage {
       .get();
     const currentVersion = versionResult?.user_version ?? 0;
 
-    if (currentVersion === 0) {
-      this.db.run("PRAGMA user_version = 1");
-    } else if (currentVersion !== 1) {
+    if (currentVersion === 0 || currentVersion === 1) {
+      await this.migrateValuesToEncryption(this.db);
+      this.db.run(`PRAGMA user_version = ${STORE_VERSION}`);
+    } else if (currentVersion !== STORE_VERSION) {
       throw new Error(
-        `Unsupported store version: ${currentVersion}. Expected: 1`
+        `Unsupported store version: ${currentVersion}. Expected: ${STORE_VERSION}`
       );
     }
 
     return this.db;
+  }
+
+  private async migrateValuesToEncryption(db: Database): Promise<void> {
+    const rows = db
+      .query<{ path: string; key: string; value: string }, []>(
+        "SELECT path, key, value FROM secrets WHERE value IS NOT NULL"
+      )
+      .all();
+
+    if (rows.length === 0) {
+      return;
+    }
+
+    interface UpdateRow {
+      path: string;
+      key: string;
+      value: string;
+    }
+
+    const updates: UpdateRow[] = [];
+    for (const row of rows) {
+      if (this.encryptor.isEncryptedValue(row.value)) {
+        continue;
+      }
+
+      updates.push({
+        path: row.path,
+        key: row.key,
+        value: await this.encryptor.encrypt(row.value),
+      });
+    }
+
+    if (updates.length === 0) {
+      return;
+    }
+
+    const updateSecret = db.query(
+      "UPDATE secrets SET value = ? WHERE path = ? AND key = ?"
+    );
+    const applyUpdates = db.transaction((pendingUpdates: UpdateRow[]) => {
+      for (const update of pendingUpdates) {
+        updateSecret.run(update.value, update.path, update.key);
+      }
+    });
+
+    applyUpdates(updates);
   }
 
   async setSecret(
@@ -106,6 +157,7 @@ export class Storage {
   ): Promise<void> {
     const db = await this.ensureDb();
     const updatedAt = new Date().toISOString();
+    const storedValue = value === null ? null : await this.encryptor.encrypt(value);
 
     db.query(`
       INSERT INTO secrets (path, key, value, updated_at)
@@ -113,7 +165,7 @@ export class Storage {
       ON CONFLICT(path, key) DO UPDATE SET
         value = excluded.value,
         updated_at = excluded.updated_at
-    `).run(canonicalPath, key, value, updatedAt);
+    `).run(canonicalPath, key, storedValue, updatedAt);
   }
 
   async getPathSecrets(canonicalPath: string): Promise<PathSecrets | undefined> {
@@ -131,8 +183,11 @@ export class Storage {
 
     const secrets: PathSecrets = {};
     for (const row of rows) {
+      const decodedValue =
+        row.value === null ? null : await this.encryptor.decrypt(row.value);
+
       secrets[row.key] = {
-        value: row.value,
+        value: decodedValue,
         updatedAt: row.updated_at,
       };
     }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -838,7 +838,7 @@ describe("Integration Tests", () => {
       const { Database } = await import("bun:sqlite");
       const db = new Database(join(ctx.configDir, "store.db"));
       const row = db
-        .query<{ value: string }, []>(
+        .query<{ value: string }, [string, string]>(
           "SELECT value FROM secrets WHERE path = ? AND key = ?"
         )
         .get(ctx.repo, "KEY");

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -825,8 +825,28 @@ describe("Integration Tests", () => {
       const { Database } = await import("bun:sqlite");
       const db = new Database(join(ctx.configDir, "store.db"));
       const version = db.query("PRAGMA user_version").get() as { user_version: number };
-      expect(version.user_version).toBe(1);
+      expect(version.user_version).toBe(2);
       db.close();
+    });
+
+    test("22b. Stored secret values are encrypted at rest", async () => {
+      await runBurrow(["set", "KEY=value"], {
+        cwd: ctx.repo,
+        configDir: ctx.configDir,
+      });
+
+      const { Database } = await import("bun:sqlite");
+      const db = new Database(join(ctx.configDir, "store.db"));
+      const row = db
+        .query<{ value: string }, []>(
+          "SELECT value FROM secrets WHERE path = ? AND key = ?"
+        )
+        .get(ctx.repo, "KEY");
+      db.close();
+
+      expect(row?.value).toBeDefined();
+      expect(row?.value).not.toBe("value");
+      expect(row?.value.startsWith("burrow:enc:v1:")).toBe(true);
     });
 
     test("23. Repeated sets don't corrupt store", async () => {
@@ -840,7 +860,7 @@ describe("Integration Tests", () => {
       const { Database } = await import("bun:sqlite");
       const db = new Database(join(ctx.configDir, "store.db"));
       const version = db.query("PRAGMA user_version").get() as { user_version: number };
-      expect(version.user_version).toBe(1);
+      expect(version.user_version).toBe(2);
       db.close();
 
       const get = await runBurrow(["get", "KEY"], {

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -48,6 +48,20 @@ describe("Storage", () => {
       const secrets = await storage.getPathSecrets("/test/path");
       expect(secrets?.["MY_KEY"]?.value).toBe("my_value");
       expect(secrets?.["MY_KEY"]?.updatedAt).toBe("2025-01-01T00:00:00.000Z");
+
+      const migratedDb = new Database(join(testDir, "store.db"));
+      const version = migratedDb.query("PRAGMA user_version").get() as { user_version: number };
+      const row = migratedDb
+        .query<{ value: string }, []>(
+          "SELECT value FROM secrets WHERE path = '/test/path' AND key = 'MY_KEY'"
+        )
+        .get();
+      migratedDb.close();
+
+      expect(version.user_version).toBe(2);
+      expect(row?.value).toBeDefined();
+      expect(row?.value).not.toBe("my_value");
+      expect(row?.value.startsWith("burrow:enc:v1:")).toBe(true);
     });
 
     test("throws on unsupported version", async () => {
@@ -83,6 +97,22 @@ describe("Storage", () => {
 
       const secrets = await storage.getPathSecrets("/test");
       expect(secrets?.["KEY"]?.value).toBeNull();
+    });
+
+    test("stores encrypted values at rest", async () => {
+      await storage.setSecret("/test", "KEY", "value");
+
+      const db = new Database(join(testDir, "store.db"));
+      const row = db
+        .query<{ value: string | null }, []>(
+          "SELECT value FROM secrets WHERE path = '/test' AND key = 'KEY'"
+        )
+        .get();
+      db.close();
+
+      expect(row?.value).toBeDefined();
+      expect(row?.value).not.toBe("value");
+      expect(row?.value?.startsWith("burrow:enc:v1:")).toBe(true);
     });
 
     test("sets updatedAt timestamp", async () => {


### PR DESCRIPTION
Adds at-rest encryption for secret values using `Bun.secrets` and provides an automatic migration strategy for existing plaintext data to resolve #5.

This implementation introduces AES-256-GCM encryption for secret values in SQLite, with keys managed by `Bun.secrets` (including a headless fallback). It also bumps the store schema version and includes an idempotent, in-place migration that transparently encrypts existing plaintext secrets upon first database access, ensuring a smooth upgrade.

---
<p><a href="https://cursor.com/agents/bc-30ee1942-dbca-4ab4-9f20-959248ad7ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30ee1942-dbca-4ab4-9f20-959248ad7ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

