### PR TITLE
feat: add dotenv import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ burrow export --format dotenv
 burrow export --format json
 ```
 
+### Import from a .env file
+
+```bash
+# Imports .env from the current directory
+burrow import
+
+# Or import a specific dotenv file into a path scope
+burrow import .env.local --path ~/projects/app
+```
+
 ### Block inheritance
 
 ```bash
@@ -125,6 +135,10 @@ const client = new BurrowClient();
 
 try {
   await client.set('API_KEY', 'secret123', { path: '/my/project' });
+  await client.import('DATABASE_URL=postgres://localhost/mydb', {
+    format: 'dotenv',
+    path: '/my/project'
+  });
 
   const secret = await client.get('API_KEY', { cwd: '/my/project/subdir' });
   console.log(secret?.value); // 'secret123'

--- a/site/index.html
+++ b/site/index.html
@@ -884,6 +884,14 @@ API_KEY  sk-live-abc123  ~/projects`;
                 </div>
 
                 <div class="command-group">
+                    <h3>Import from .env</h3>
+                    <p>Import secrets from a dotenv file into the current directory scope:</p>
+                    <pre><code>burrow import .env</code></pre>
+                    <p>Scope imported secrets to another directory:</p>
+                    <pre><code>burrow import .env --path ~/projects/myapp</code></pre>
+                </div>
+
+                <div class="command-group">
                     <h3>Auto-load secrets</h3>
                     <p>Set up automatic loading when you enter a trusted directory:</p>
                     <pre><code># Install the shell hook (one-time setup)
@@ -924,6 +932,10 @@ burrow trust .</code></pre>
                         <tr>
                             <td>burrow export</td>
                             <td>Export secrets as environment variables</td>
+                        </tr>
+                        <tr>
+                            <td>burrow import [file]</td>
+                            <td>Import secrets from a dotenv file</td>
                         </tr>
                         <tr>
                             <td>burrow unset &lt;key&gt;</td>

--- a/src/api.ts
+++ b/src/api.ts
@@ -15,6 +15,9 @@ import {
   generateShellCommands,
   resolveToLoadedSecrets,
   computeHookDiff,
+  parseImport,
+  type ImportFormat,
+  type ImportedSecret,
 } from "./core/index.ts";
 import { type TrustedPath } from "./storage/index.ts";
 
@@ -23,6 +26,7 @@ export type { ExportFormat };
 export type { TrustCheckResult };
 export type { LoadedSecret, HookDiff };
 export type { TrustedPath };
+export type { ImportFormat, ImportedSecret };
 
 /**
  * Configuration options for creating a BurrowClient instance.
@@ -230,6 +234,39 @@ export interface ExportOptions {
    * Only applies when format is `json`.
    */
   includeSources?: boolean;
+}
+
+/**
+ * Options for the `import` method.
+ */
+export interface ImportOptions {
+  /**
+   * Import format parser to use.
+   * Defaults to `dotenv`.
+   */
+  format?: ImportFormat;
+
+  /**
+   * Directory path to scope imported secrets to.
+   * Defaults to the current working directory.
+   */
+  path?: string;
+}
+
+/**
+ * Result of the `import` method.
+ */
+export interface ImportResult {
+  /**
+   * The canonicalized path that imported secrets were scoped to.
+   */
+  path: string;
+
+  /**
+   * Imported secret entries, in file order with duplicate keys collapsed to
+   * the last value found in the source.
+   */
+  imported: ImportedSecret[];
 }
 
 /**
@@ -469,6 +506,40 @@ export class BurrowClient {
     return format(secrets, fmt, {
       includeSources: options.includeSources,
     });
+  }
+
+  /**
+   * Imports secrets from a serialized source into the store.
+   *
+   * The imported secrets are written at a single path scope. If a key appears
+   * multiple times in the import source, the last value wins.
+   *
+   * @param content - Serialized secrets to import
+   * @param options - Import options including format and target path
+   * @returns Import result including the target path and imported keys
+   *
+   * @example
+   * ```typescript
+   * await client.import('API_KEY=secret\nDATABASE_URL=postgres://...', {
+   *   format: 'dotenv',
+   *   path: '/projects/myapp'
+   * });
+   * ```
+   */
+  async import(content: string, options: ImportOptions = {}): Promise<ImportResult> {
+    const format = options.format ?? "dotenv";
+    const imported = parseImport(content, { format });
+    const targetPath = options.path ?? process.cwd();
+    const canonicalPath = await canonicalize(targetPath, this.pathOptions);
+
+    for (const secret of imported) {
+      await this.storage.setSecret(canonicalPath, secret.key, secret.value);
+    }
+
+    return {
+      path: canonicalPath,
+      imported,
+    };
   }
 
   /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command, Option } from "commander";
-import { BurrowClient, type ExportFormat } from "./api.ts";
+import { BurrowClient, type ExportFormat, type ImportFormat } from "./api.ts";
 import clipboardy from "clipboardy";
 import { ReleaseNotifier } from "gh-release-update-notifier";
 import { spawn } from "child_process";
@@ -289,6 +289,32 @@ program
           console.error("Warning: Could not copy to clipboard");
         }
       }
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("import")
+  .description("Import secrets from a file")
+  .argument("[file]", "File to import (default: .env)")
+  .addOption(new Option("-f, --format <format>", "Import format").choices(["dotenv"]).default("dotenv"))
+  .option("-p, --path <dir>", "Directory to scope imported secrets to (default: cwd)", validatePath)
+  .action(async (fileArg: string | undefined, options: { format: string; path?: string }) => {
+    using client = new BurrowClient();
+    const filePath = fileArg ?? ".env";
+
+    try {
+      const content = await Bun.file(filePath).text();
+      const result = await client.import(content, {
+        format: options.format as ImportFormat,
+        path: options.path,
+      });
+
+      const count = result.imported.length;
+      const secretLabel = count === 1 ? "secret" : "secrets";
+      console.log(`Imported ${count} ${secretLabel} from ${filePath} to ${result.path}`);
     } catch (error) {
       console.error(`Error: ${(error as Error).message}`);
       process.exit(1);

--- a/src/core/importer.ts
+++ b/src/core/importer.ts
@@ -1,0 +1,141 @@
+import { assertValidEnvKey } from "./formatter.ts";
+
+export type ImportFormat = "dotenv";
+
+export interface ImportedSecret {
+  key: string;
+  value: string;
+}
+
+export interface ParseImportOptions {
+  format: ImportFormat;
+}
+
+type ImportParser = (content: string) => ImportedSecret[];
+
+function stripInlineComment(value: string): string {
+  return value.replace(/\s+#.*$/, "").trim();
+}
+
+function parseDoubleQuotedValue(text: string, lineNumber: number): string {
+  let value = "";
+
+  for (let index = 1; index < text.length; index++) {
+    const char = text[index];
+
+    if (char === undefined) {
+      break;
+    }
+
+    if (char === '"') {
+      const trailing = text.slice(index + 1).trim();
+      if (trailing !== "" && !trailing.startsWith("#")) {
+        throw new Error(`Invalid dotenv syntax on line ${lineNumber}: unexpected content after quoted value`);
+      }
+      return value;
+    }
+
+    if (char === "\\") {
+      const next = text[index + 1];
+      if (next === undefined) {
+        value += char;
+        continue;
+      }
+
+      switch (next) {
+        case "n":
+          value += "\n";
+          break;
+        case "r":
+          value += "\r";
+          break;
+        case "t":
+          value += "\t";
+          break;
+        case "\\":
+          value += "\\";
+          break;
+        case '"':
+          value += '"';
+          break;
+        default:
+          value += next;
+          break;
+      }
+      index++;
+      continue;
+    }
+
+    value += char;
+  }
+
+  throw new Error(`Invalid dotenv syntax on line ${lineNumber}: unterminated quoted value`);
+}
+
+function parseSingleQuotedValue(text: string, lineNumber: number): string {
+  const closingIndex = text.indexOf("'", 1);
+  if (closingIndex === -1) {
+    throw new Error(`Invalid dotenv syntax on line ${lineNumber}: unterminated quoted value`);
+  }
+
+  const trailing = text.slice(closingIndex + 1).trim();
+  if (trailing !== "" && !trailing.startsWith("#")) {
+    throw new Error(`Invalid dotenv syntax on line ${lineNumber}: unexpected content after quoted value`);
+  }
+
+  return text.slice(1, closingIndex);
+}
+
+export function parseDotenv(content: string): ImportedSecret[] {
+  const secrets = new Map<string, string>();
+  const lines = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+
+  for (const [index, rawLine] of lines.entries()) {
+    const lineNumber = index + 1;
+    let line = rawLine.trim();
+
+    if (line === "" || line.startsWith("#")) {
+      continue;
+    }
+
+    if (line.startsWith("export ")) {
+      line = line.slice("export ".length).trimStart();
+    }
+
+    const equalsIndex = line.indexOf("=");
+    if (equalsIndex === -1) {
+      throw new Error(`Invalid dotenv syntax on line ${lineNumber}: expected KEY=VALUE`);
+    }
+
+    const key = line.slice(0, equalsIndex).trim();
+    assertValidEnvKey(key);
+
+    const valueText = line.slice(equalsIndex + 1).trimStart();
+    let value: string;
+
+    if (valueText.startsWith('"')) {
+      value = parseDoubleQuotedValue(valueText, lineNumber);
+    } else if (valueText.startsWith("'")) {
+      value = parseSingleQuotedValue(valueText, lineNumber);
+    } else {
+      value = stripInlineComment(valueText);
+    }
+
+    secrets.set(key, value);
+  }
+
+  return Array.from(secrets, ([key, value]) => ({ key, value }));
+}
+
+const IMPORT_PARSERS: Record<ImportFormat, ImportParser> = {
+  dotenv: parseDotenv,
+};
+
+export function parseImport(content: string, options: ParseImportOptions): ImportedSecret[] {
+  const parser = IMPORT_PARSERS[options.format];
+  if (!parser) {
+    throw new Error(`Unsupported import format: ${options.format}`);
+  }
+
+  return parser(content);
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from "./path.ts";
 export * from "./resolver.ts";
 export * from "./formatter.ts";
+export * from "./importer.ts";
 export * from "./trust.ts";
 export * from "./hook.ts";

--- a/src/storage/encryption.ts
+++ b/src/storage/encryption.ts
@@ -118,6 +118,10 @@ export class SecretValueEncryptor {
   }
 
   private async readKeyFromBunSecrets(): Promise<Buffer | undefined> {
+    if (!canUseBunSecrets()) {
+      return undefined;
+    }
+
     let keyMaterial: string | null;
 
     try {
@@ -145,6 +149,10 @@ export class SecretValueEncryptor {
   }
 
   private async tryStoreInBunSecrets(key: Buffer): Promise<boolean> {
+    if (!canUseBunSecrets()) {
+      return false;
+    }
+
     try {
       await Bun.secrets.set({
         service: ENCRYPTION_SERVICE,
@@ -158,6 +166,10 @@ export class SecretValueEncryptor {
   }
 
   private async readKeyFromLegacyService(): Promise<string | null> {
+    if (!canUseBunSecrets()) {
+      return null;
+    }
+
     try {
       return await Bun.secrets.get({
         service: LEGACY_ENCRYPTION_SERVICE,
@@ -191,6 +203,20 @@ export class SecretValueEncryptor {
       await chmod(this.fallbackKeyPath, 0o600);
     }
   }
+}
+
+function canUseBunSecrets(): boolean {
+  if (process.env["BURROW_DISABLE_BUN_SECRETS"] === "1") {
+    return false;
+  }
+
+  // On headless Linux systems without a session bus, libsecret-backed
+  // keyring calls can block indefinitely. Use the file fallback there.
+  if (process.platform === "linux" && !process.env["DBUS_SESSION_BUS_ADDRESS"]) {
+    return false;
+  }
+
+  return true;
 }
 
 function parseKeyMaterial(value: string, source: string): Buffer {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -239,6 +239,43 @@ describe("BurrowClient", () => {
     });
   });
 
+  describe("import", () => {
+    test("imports dotenv secrets at the default path", async () => {
+      const result = await client.import("API_KEY=secret\nDATABASE_URL=postgres://localhost/db", {
+        path: testDir,
+      });
+
+      expect(result.path).toBe(testDir);
+      expect(result.imported).toEqual([
+        { key: "API_KEY", value: "secret" },
+        { key: "DATABASE_URL", value: "postgres://localhost/db" },
+      ]);
+
+      const apiKey = await client.get("API_KEY", { cwd: testDir });
+      const databaseUrl = await client.get("DATABASE_URL", { cwd: testDir });
+      expect(apiKey?.value).toBe("secret");
+      expect(databaseUrl?.value).toBe("postgres://localhost/db");
+    });
+
+    test("overwrites existing values with imported values", async () => {
+      await client.set("API_KEY", "old", { path: testDir });
+
+      await client.import("API_KEY=new", { path: testDir });
+
+      const secret = await client.get("API_KEY", { cwd: testDir });
+      expect(secret?.value).toBe("new");
+    });
+
+    test("throws without writing any secrets when import validation fails", async () => {
+      await expect(
+        client.import("GOOD=value\nBAD-KEY=value", { path: testDir })
+      ).rejects.toThrow("Invalid environment variable key");
+
+      const secret = await client.get("GOOD", { cwd: testDir });
+      expect(secret).toBeUndefined();
+    });
+  });
+
   describe("resolve", () => {
     test("returns Map of resolved secrets", async () => {
       await client.set("KEY1", "value1", { path: testDir });

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { parseDotenv } from "../src/core/importer.ts";
+
+describe("dotenv importer", () => {
+  test("parses comments, blank lines, export prefix, and quoted values", () => {
+    const imported = parseDotenv(`
+# ignored
+export API_KEY=abc123
+DATABASE_URL="postgres://user:pass@example.com/db"
+MESSAGE='hello world'
+URL=https://example.com/#fragment
+INLINE_COMMENT=value # ignored
+EMPTY=
+`);
+
+    expect(imported).toEqual([
+      { key: "API_KEY", value: "abc123" },
+      { key: "DATABASE_URL", value: "postgres://user:pass@example.com/db" },
+      { key: "MESSAGE", value: "hello world" },
+      { key: "URL", value: "https://example.com/#fragment" },
+      { key: "INLINE_COMMENT", value: "value" },
+      { key: "EMPTY", value: "" },
+    ]);
+  });
+
+  test("uses the last value when a key appears multiple times", () => {
+    const imported = parseDotenv("API_KEY=first\nAPI_KEY=second");
+
+    expect(imported).toEqual([{ key: "API_KEY", value: "second" }]);
+  });
+
+  test("decodes common double-quoted escape sequences", () => {
+    const imported = parseDotenv(String.raw`QUOTED="line1\nline2\t\"quoted\""`);
+
+    expect(imported).toEqual([{ key: "QUOTED", value: 'line1\nline2\t"quoted"' }]);
+  });
+
+  test("throws for invalid dotenv syntax", () => {
+    expect(() => parseDotenv("MISSING_EQUALS")).toThrow("expected KEY=VALUE");
+    expect(() => parseDotenv("BAD-KEY=value")).toThrow("Invalid environment variable key");
+    expect(() => parseDotenv('API_KEY="unterminated')).toThrow("unterminated quoted value");
+  });
+});

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdir, rm, symlink } from "node:fs/promises";
+import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -544,6 +544,65 @@ describe("Integration Tests", () => {
       });
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr).toContain("Invalid");
+    });
+  });
+
+  describe("Import command", () => {
+    test("imports dotenv files into the current directory scope", async () => {
+      const envPath = join(ctx.repo, ".env");
+      await writeFile(envPath, "API_KEY=secret\nDATABASE_URL=postgres://localhost/db\n");
+
+      const result = await runBurrow(["import"], {
+        cwd: ctx.repo,
+        configDir: ctx.configDir,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`Imported 2 secrets from .env to ${ctx.repo}`);
+
+      const exported = await runBurrow(["export", "--format", "json"], {
+        cwd: ctx.repo,
+        configDir: ctx.configDir,
+      });
+
+      expect(JSON.parse(exported.stdout)).toEqual({
+        API_KEY: "secret",
+        DATABASE_URL: "postgres://localhost/db",
+      });
+    });
+
+    test("imports a specified dotenv file into a path scope", async () => {
+      const envPath = join(ctx.root, "repo.env");
+      await writeFile(envPath, "SCOPED=value\n");
+
+      const result = await runBurrow(["import", envPath, "--path", ctx.sub], {
+        cwd: ctx.root,
+        configDir: ctx.configDir,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`Imported 1 secret from ${envPath} to ${ctx.sub}`);
+
+      const get = await runBurrow(["get", "SCOPED", "--format", "json"], {
+        cwd: ctx.sub,
+        configDir: ctx.configDir,
+      });
+
+      expect(get.exitCode).toBe(0);
+      expect(JSON.parse(get.stdout).sourcePath).toBe(ctx.sub);
+    });
+
+    test("reports invalid dotenv keys", async () => {
+      const envPath = join(ctx.repo, ".env");
+      await writeFile(envPath, "BAD-KEY=value\n");
+
+      const result = await runBurrow(["import"], {
+        cwd: ctx.repo,
+        configDir: ctx.configDir,
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("Invalid environment variable key");
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a reusable import parser layer with dotenv support
- Expose `BurrowClient.import(...)` and wire `burrow import [file]`
- Document import usage in README and the public site
- Ensure headless Linux environments use the documented on-disk encryption key fallback instead of hanging on unavailable keyring calls

## Verification
- `bun run typecheck`
- `bun test` *(rerunning after headless fallback fix)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71deac37-e3d1-43fa-a89d-62d666b94569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71deac37-e3d1-43fa-a89d-62d666b94569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

